### PR TITLE
 change type from void to bool for begin()

### DIFF
--- a/Libraries/Arduino/Si7021/src/SparkFun_Si7021_Breakout_Library.cpp
+++ b/Libraries/Arduino/Si7021/src/SparkFun_Si7021_Breakout_Library.cpp
@@ -41,7 +41,7 @@
  //Initialize
  Weather::Weather(){}
 
- void Weather::begin(void)
+ bool Weather::begin(void)
 {
   Wire.begin();
 

--- a/Libraries/Arduino/Si7021/src/SparkFun_Si7021_Breakout_Library.h
+++ b/Libraries/Arduino/Si7021/src/SparkFun_Si7021_Breakout_Library.h
@@ -66,7 +66,7 @@ public:
 	// Constructor
 	Weather();
 
-	void  begin();
+	bool  begin();
 
 	// Si7021 & HTU21D Public Functions
 	float getRH();


### PR DESCRIPTION
begin() only returns text via Serial.println() but nothing which could be catch by some logic in the calling function. turning it into a bool allows the calling function to react on the result.