### PR TITLE
Added "return true" to begin function.

### DIFF
--- a/Libraries/Arduino/Si7021/src/SparkFun_Si7021_Breakout_Library.cpp
+++ b/Libraries/Arduino/Si7021/src/SparkFun_Si7021_Breakout_Library.cpp
@@ -59,11 +59,13 @@
   if(x == 1)
   {
     Serial.println("Si7021 Found");
+    return true;
     //Serial.println(ID_Temp_Hum, HEX);
   }
   else if(x == 2)
   {
     Serial.println("HTU21D Found");
+    return true;
     //Serial.println(ID_Temp_Hum, HEX);
   }
   else

--- a/Libraries/Arduino/Si7021/src/SparkFun_Si7021_Breakout_Library.cpp
+++ b/Libraries/Arduino/Si7021/src/SparkFun_Si7021_Breakout_Library.cpp
@@ -69,8 +69,11 @@
     //Serial.println(ID_Temp_Hum, HEX);
   }
   else
-  	Serial.println("No Devices Detected");
-  	//Serial.println(ID_Temp_Hum, HEX);
+  {
+    Serial.println("No Devices Detected");
+    return false;
+    //Serial.println(ID_Temp_Hum, HEX);
+  }
 }
 
 /****************Si7021 & HTU21D Functions**************************************/


### PR DESCRIPTION
As the "begin" function is reporting to return a bool, I expected that I could use it in a similar fashion:

```
if (!sensor.begin()) {
    Serial.println("Could not find a valid Si7021 sensor, check wiring!");
}
```
But as the function returns nothing so far, this fails. Added "return true" in two points of the function where it actually finds a sensor. 